### PR TITLE
Fix send_feedback default noop function

### DIFF
--- a/apnsmock
+++ b/apnsmock
@@ -35,7 +35,7 @@ class MockGateway(object):
         `send_errors`: Callable sends error response code if >= 0.
         `send_feedback`: Callable returns True if token should be added to feedback
         """
-        self.send_errors = send_errors or (lambda x: -1)
+        self.send_errors = send_errors or (lambda: -1)
         self.send_feedback = send_feedback or (lambda: False)
 
         if not callable(self.send_errors):


### PR DESCRIPTION
Ran into this when using `--errors`.

By the way, thanks for the useful tool!
